### PR TITLE
Use the 'api_secret' config field rather than 'application_id'

### DIFF
--- a/src/VonageServiceProvider.php
+++ b/src/VonageServiceProvider.php
@@ -102,7 +102,7 @@ class VonageServiceProvider extends ServiceProvider
         $basicCredentials = null;
         if ($this->vonageConfigHas('api_secret')) {
             $basicCredentials = $this->createBasicCredentials($this->config['api_key'],
-                $this->config['application_id']);
+                $this->config['api_secret']);
         }
 
         $signatureCredentials = null;


### PR DESCRIPTION
Hey!

I've been tinkering with sending WhatsApp messages using this package and kept running into an authentication issue. I had a look through the service provider and I think I might have found the issue.

It seems that the `application_id` field is being used for the basic credentials rather than the `api_secret` field.

I've only been using this package for an hour or so, so I might be wrong, and this might be intentional. I do apologise if that's the case!

Hopefully, this is a bug that I've fixed though? 😄