### PR TITLE
Add the "provider" argument to the publish command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can use `artisan vendor:publish` to copy the distribution configuration file
 config directory:
 
 ```bash
-php artisan vendor:publish
+php artisan vendor:publish --provider="Vonage\Laravel\VonageServiceProvider"
 ```
 
 Then update `config/vonage.php` with your credentials. Alternatively, you can update your `.env` file 


### PR DESCRIPTION
Hey! This PR is only a small one, but something that I thought might make the installation process even quicker for devs.

At the moment, if you run the `php artisan vendor:publish` command (like shown in the docs at the moment), then the user will then need to select the Vonage provider to publish the config.

With my proposed change, running the command that I've proposed _should_ remove this extra step of having to select the provider. So the user should be able to copy and paste the command into their terminal, hit ENTER, and then the config file will be published.

I hope this all sounds okay and that I've done it right. If this is something you'd consider merging and there are any changes you'd like me to make, feel free to give me a shout 😄