### PR TITLE
Version bumps for patch release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ This is a Laravel Service Provider for integrating the [Vonage PHP Client Librar
 
 ### Requirements
 
-This Package is for use with Laravel versions 6.0 and upwards.
+This Package is for use with Laravel versions 9and upwards due to PHP Version restrictions. You will need to be running
+PHP8.0 and upwards - for older compatibility you will need to look at previous versions.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a Laravel Service Provider for integrating the [Vonage PHP Client Librar
 
 ### Requirements
 
-This Package is for use with Laravel versions 9and upwards due to PHP Version restrictions. You will need to be running
+This Package is for use with Laravel versions 9.x and upwards due to PHP Version restrictions. You will need to be running
 PHP8.0 and upwards - for older compatibility you will need to look at previous versions.
 
 ### Installation

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "Service provider for Laravel for the Vonage PHP SDK",
     "type": "package",
     "require": {
-        "vonage/client": "^3.0",
-        "php": "^7.4|^8.0|^8.1",
-        "illuminate/support": "^7.0|^8.0|^9.0"
+        "vonage/client": "^4.0",
+        "php": "^8.0|^8.1|^8.2",
+        "illuminate/support": "^9.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",


### PR DESCRIPTION
Vonage Core SDK has now dropped EOL support for PHP7.x
This means this package is now only compatible with Laravel 9.x onwards.