### PR TITLE
Clean tests, clean provider, run CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+---
+name: build
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [ '8.0', '8.1', '8.2' ]
+
+    name: PHP ${{ matrix.php }} Test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: json, mbstring
+          coverage: pcov
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Get Composer cache directory
+        id: composercache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction
+
+      - name: Analyze & test
+        run: composer test -- -v --coverage-clover=coverage.xml
+
+      - name: Run codecov
+        uses: codecov/codecov-action@v1

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ $outboundCall
 $response = Vonage::voice()->createOutboundCall($outboundCall);
 ```
 
-For more information on using the Vonage client library, see 
+For more information on using the Vonage Client library, see 
 the [official client library repository](https://github.com/Vonage/vonage-php-sdk-core).
 
-[client-library]: https://github.com/Nexmo/nexmo-php
+[client-library]: https://github.com/Vonage/vonage-php

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Vonage\Laravel\Tests;
 
+use Illuminate\Foundation\Application;
 use Orchestra\Testbench\TestCase;
 use Vonage\Laravel\VonageServiceProvider;
 use Vonage\Client;
@@ -11,11 +12,11 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Get package providers.
      *
-     * @param  \Illuminate\Foundation\Application $app
+     * @param  Application $app
      *
      * @return array
      */
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
             VonageServiceProvider::class,
@@ -25,11 +26,11 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Get package aliases.
      *
-     * @param  \Illuminate\Foundation\Application $app
+     * @param  Application $app
      *
      * @return array
      */
-    protected function getPackageAliases($app)
+    protected function getPackageAliases($app): array
     {
         return [
             'Vonage' => \Vonage\Laravel\Facade\Vonage::class,
@@ -41,11 +42,12 @@ abstract class AbstractTestCase extends TestCase
      *
      * @param string $class
      * @param string $property
-     * @param mixed  $object
+     * @param mixed $object
      *
      * @return mixed
+     * @throws \ReflectionException
      */
-    public function getClassProperty($class, $property, $object)
+    public function getClassProperty(string $class, string $property, mixed $object): mixed
     {
         $reflectionClass = new \ReflectionClass($class);
         $refProperty = $reflectionClass->getProperty($property);

--- a/tests/TestClientBasicAPICredentials.php
+++ b/tests/TestClientBasicAPICredentials.php
@@ -2,6 +2,7 @@
 
 namespace Vonage\Laravel\Tests;
 
+use Illuminate\Foundation\Application;
 use Vonage\Client;
 
 class TestClientBasicAPICredentials extends AbstractTestCase
@@ -9,18 +10,18 @@ class TestClientBasicAPICredentials extends AbstractTestCase
     /**
      * Define environment setup.
      *
-     * @param  \Illuminate\Foundation\Application $app
+     * @param  Application $app
      *
      * @return void
      */
-    protected function getEnvironmentSetUp($app)
+    protected function defineEnvironment($app): void
     {
         $app['config']->set('vonage.api_key', 'my_api_key');
         $app['config']->set('vonage.api_secret', 'my_secret');
     }
 
     /**
-     * Test that our Nexmo client is created with
+     * Test that our Vonage client is created with
      * the Basic API credentials.
      *
      * @return void

--- a/tests/TestClientPrivateKeyBasicCredentials.php
+++ b/tests/TestClientPrivateKeyBasicCredentials.php
@@ -2,6 +2,7 @@
 
 namespace Vonage\Laravel\Tests;
 
+use Illuminate\Foundation\Application;
 use Vonage\Client;
 
 class TestClientPrivateKeyBasicCredentials extends AbstractTestCase
@@ -9,11 +10,11 @@ class TestClientPrivateKeyBasicCredentials extends AbstractTestCase
     /**
      * Define environment setup.
      *
-     * @param  \Illuminate\Foundation\Application $app
+     * @param  Application $app
      *
      * @return void
      */
-    protected function getEnvironmentSetUp($app)
+    protected function getEnvironmentSetUp($app): void
     {
         $app['config']->set('vonage.private_key', '/path/to/key');
         $app['config']->set('vonage.application_id', 'application-id-123');
@@ -22,14 +23,14 @@ class TestClientPrivateKeyBasicCredentials extends AbstractTestCase
     }
 
     /**
-     * Test that our Nexmo client is created with
+     * Test that our Vonage client is created with
      * a container with key + basic credentials.
      *
      * @dataProvider classNameProvider
      *
      * @return void
      */
-    public function testClientCreatedWithPrivateKeyBasicCredentials($className)
+    public function testClientCreatedWithPrivateKeyBasicCredentials($className): void
     {
         $client = app($className);
         $credentialsObject = $this->getClassProperty(Client::class, 'credentials', $client);

--- a/tests/TestClientPrivateKeyCredentials.php
+++ b/tests/TestClientPrivateKeyCredentials.php
@@ -2,6 +2,7 @@
 
 namespace Vonage\Laravel\Tests;
 
+use Illuminate\Foundation\Application;
 use Vonage\Client;
 
 class TestClientPrivateKeyCredentials extends AbstractTestCase
@@ -9,21 +10,24 @@ class TestClientPrivateKeyCredentials extends AbstractTestCase
     /**
      * Define environment setup.
      *
-     * @param  \Illuminate\Foundation\Application $app
+     * @param  Application $app
      *
      * @return void
      */
-    protected function getEnvironmentSetUp($app)
+    protected function getEnvironmentSetUp($app): void
     {
         $app['config']->set('vonage.private_key', '/path/to/key');
         $app['config']->set('vonage.application_id', 'application-id-123');
     }
 
     /**
-     * Test that our Nexmo client is created with
+     * Test that our Vonage client is created with
      * the private key credentials
      *
      * @dataProvider classNameProvider
+     *
+     * @param $className
+     *
      * @return void
      */
     public function testClientCreatedWithPrivateKeyCredentials($className): void

--- a/tests/TestClientPrivateKeySignatureCredentials.php
+++ b/tests/TestClientPrivateKeySignatureCredentials.php
@@ -2,6 +2,7 @@
 
 namespace Vonage\Laravel\Tests;
 
+use Illuminate\Foundation\Application;
 use Vonage\Client;
 
 class TestClientPrivateKeySignatureCredentials extends AbstractTestCase
@@ -9,11 +10,11 @@ class TestClientPrivateKeySignatureCredentials extends AbstractTestCase
     /**
      * Define environment setup.
      *
-     * @param  \Illuminate\Foundation\Application $app
+     * @param  Application $app
      *
      * @return void
      */
-    protected function getEnvironmentSetUp($app)
+    protected function getEnvironmentSetUp($app): void
     {
         $app['config']->set('vonage.private_key', '/path/to/key');
         $app['config']->set('vonage.application_id', 'application-id-123');
@@ -22,10 +23,12 @@ class TestClientPrivateKeySignatureCredentials extends AbstractTestCase
     }
 
     /**
-     * Test that our Nexmo client is created with
+     * Test that our Vonage client is created with
      * a container with private key + signature credentials
      *
      * @dataProvider classNameProvider
+     *
+     * @param $className
      *
      * @return void
      */

--- a/tests/TestClientSignatureAPICredentials.php
+++ b/tests/TestClientSignatureAPICredentials.php
@@ -2,6 +2,7 @@
 
 namespace Vonage\Laravel\Tests;
 
+use Illuminate\Foundation\Application;
 use Vonage\Client;
 
 class TestClientSignatureAPICredentials extends AbstractTestCase
@@ -9,21 +10,24 @@ class TestClientSignatureAPICredentials extends AbstractTestCase
     /**
      * Define environment setup.
      *
-     * @param  \Illuminate\Foundation\Application $app
+     * @param  Application $app
      *
      * @return void
      */
-    protected function getEnvironmentSetUp($app)
+    protected function getEnvironmentSetUp($app): void
     {
         $app['config']->set('vonage.api_key', 'my_api_key');
         $app['config']->set('vonage.signature_secret', 'my_signature');
     }
 
     /**
-     * Test that our Nexmo client is created with
+     * Test that our Vonage client is created with
      * the signature credentials
      *
      * @dataProvider classNameProvider
+     *
+     * @param $className
+     *
      * @return void
      */
     public function testClientCreatedWithSignatureAPICredentials($className): void

--- a/tests/TestNoVonageConfiguration.php
+++ b/tests/TestNoVonageConfiguration.php
@@ -2,27 +2,29 @@
 
 namespace Vonage\Laravel\Tests;
 
-use Vonage\Client;
+use Illuminate\Foundation\Application;
 
 class TestNoVonageConfiguration extends AbstractTestCase
 {
     /**
      * Define environment setup.
      *
-     * @param  \Illuminate\Foundation\Application $app
+     * @param  Application $app
      *
      * @return void
      */
-    protected function getEnvironmentSetUp($app)
+    protected function getEnvironmentSetUp($app): void
     {
         $app['config']->set('vonage.api_key', 'my_api_key');
     }
 
     /**
-     * Test that when we do not supply Nexmo configuration
+     * Test that when we do not supply Vonage configuration
      * a Runtime exception is generated under the Vonage namespace.
      *
      * @dataProvider classNameProvider
+     *
+     * @param $className
      *
      * @return void
      */

--- a/tests/TestServiceProvider.php
+++ b/tests/TestServiceProvider.php
@@ -1,16 +1,15 @@
 <?php
 
-namespace Nexmo\Laravel\Tests;
+namespace Vonage\Laravel\Tests;
 
-use Vonage\Client;
-use Vonage\Laravel\Tests\AbstractTestCase;
+use Illuminate\Foundation\Application;
 
 class TestServiceProvider extends AbstractTestCase
 {
     /**
      * Define environment setup.
      *
-     * @param  \Illuminate\Foundation\Application $app
+     * @param  Application $app
      *
      * @return void
      */
@@ -25,6 +24,8 @@ class TestServiceProvider extends AbstractTestCase
      * from container binding.
      *
      * @dataProvider classNameProvider
+     *
+     * @param $className
      *
      * @return void
      */


### PR DESCRIPTION
#11 added a breaking bug that could have easily been fixed by a CI runner firing PHP unit.
This PR firstly adds phpunit into the pipeline.

It also contains cleaning for the ServiceProvider, and fixes the actual bug whereby we have array config keys for Laravel, but did not consider the value.