### PR TITLE
Allow PHPUnit 11 as laravel 11 allow phpunit 11 too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",
-        "phpunit/phpunit": "^5.3|~6.0|~8.0|~9.0|^10.5",
+        "phpunit/phpunit": "^5.3|~6.0|~8.0|~9.0|^10.5|^11.0",
         "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^9.0"
     },
     "license": "MIT",


### PR DESCRIPTION
also, the previous PR u merged for laravel 11 u forgot to tag a new release @SecondeJK 